### PR TITLE
refactor: add website tab logo

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -21,4 +21,7 @@
 <!-- Template Stylesheet -->
 <link href={{ asset('css/main.css')}} rel="stylesheet">
 
+<!-- Website tab logo -->
+<link rel="icon" type="image/png" href={{ asset('tab-website-logo.png') }}>
+
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>


### PR DESCRIPTION
## Description

Add a "link" tag to the header.blade.php partial file with an attribute of rel="icon" and a href that point to the tab-website-logo.png url, this way an icon can be shown in the browser website tab. The website looks more professional this way.